### PR TITLE
Update CI/CD workflow for Jekyll site deployment to GitHub Pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,147 +1,55 @@
-name: EcoPoint CI/CD
+name: Deploy Jekyll Site to GitHub Pages
 
 on:
+  # Triggers on push to main branch
   push:
     branches:
       - main
-  pull_request:
+  # Allows manual triggering from the Actions tab
   workflow_dispatch:
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
-  packages: write
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
-  compose-validation:
-    name: Validate Docker Compose
+  # Build job
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Validate compose file
-        run: docker compose -f docker-compose.yml config
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
 
-  frontend:
-    name: Frontend lint and build
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./docs/_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs/_site
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    needs: build
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Install dependencies
-        working-directory: frontend
-        run: npm ci
-
-      - name: Lint frontend
-        working-directory: frontend
-        run: npm run lint
-
-      - name: Build frontend
-        working-directory: frontend
-        run: npm run build
-
-  backend:
-    name: Backend build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: backend/package-lock.json
-
-      - name: Install dependencies
-        working-directory: backend
-        run: npm ci
-
-      - name: Build backend
-        working-directory: backend
-        run: npm run build
-
-  ai:
-    name: AI syntax check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-
-      - name: Install uv
-        run: pip install uv
-
-      - name: Sync AI dependencies
-        working-directory: ai
-        run: uv sync --frozen
-
-      - name: Compile AI sources
-        working-directory: ai
-        run: uv run python -m py_compile main.py classify.py
-
-  docker-images:
-    name: Build and publish Docker images
-    runs-on: ubuntu-latest
-    needs:
-      - compose-validation
-      - frontend
-      - backend
-      - ai
-    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push AI image
-        uses: docker/build-push-action@v6
-        with:
-          context: ./ai
-          file: ./ai/Dockerfile
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/ecopoint-ai:latest
-            ghcr.io/${{ github.repository_owner }}/ecopoint-ai:${{ github.sha }}
-
-      - name: Build and push Backend image
-        uses: docker/build-push-action@v6
-        with:
-          context: ./backend
-          file: ./backend/Dockerfile
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/ecopoint-backend:latest
-            ghcr.io/${{ github.repository_owner }}/ecopoint-backend:${{ github.sha }}
-
-      - name: Build and push Frontend image
-        uses: docker/build-push-action@v6
-        with:
-          context: ./frontend
-          file: ./frontend/Dockerfile
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/ecopoint-frontend:latest
-            ghcr.io/${{ github.repository_owner }}/ecopoint-frontend:${{ github.sha }}
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request significantly changes the GitHub Actions workflow by replacing the previous multi-service CI/CD pipeline with a streamlined workflow for building and deploying a Jekyll site to GitHub Pages. The new workflow focuses exclusively on deploying the contents of the `docs` directory, removing all jobs related to Docker, frontend, backend, and AI validation.

The most important changes are:

**Workflow focus and simplification:**
* The workflow is now dedicated to building and deploying the Jekyll site from the `docs` directory to GitHub Pages, removing all previous CI/CD jobs for Docker images, frontend, backend, and AI services.
* All jobs related to Docker Compose validation, frontend lint/build, backend build, AI syntax check, and Docker image publishing have been removed.

**Deployment configuration:**
* Added a build job using `actions/jekyll-build-pages@v1` to generate the site and `actions/upload-pages-artifact@v3` to upload the build output.
* Introduced a dedicated deploy job using `actions/deploy-pages@v4` to publish the site to GitHub Pages.
* Updated permissions for the `GITHUB_TOKEN` to allow deployment to GitHub Pages, and added concurrency controls to prevent overlapping deployments.

**Workflow triggers and permissions:**
* The workflow